### PR TITLE
Add support for docker build target arg

### DIFF
--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -88,6 +88,10 @@ export function build(docker, options) {
     var done = originalDefer();
     var build_options = { t: opts.tag, forcerm: true, nocache: !opts.cache, q: !opts.verbose };
 
+    if (!_.isEmpty(opts.target)) {
+      build_options.target = opts.target;
+    }
+
     // Start stream
     var stream = yield docker.buildImage(archive, build_options).catch((err) => {
       throw new DockerBuildError('server_error', { dockerfile, err });

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -27,6 +27,7 @@ export class Image {
         this.name = options[this.provider];
       } else if (this.provider === 'dockerfile') {
         this.path = options[this.provider];
+        this.target = options.target;
       }
     } else {
       if (this.provider === 'dockerfile') {
@@ -34,6 +35,7 @@ export class Image {
       }
       this.repository = options.repository;
       this.tag        = this.tag || options.tag || DEFAULT_TAG;
+      this.target     = options.target;
     }
 
     if (_.isEmpty(this.name)) {
@@ -86,6 +88,7 @@ export class Image {
       let build_opts = {
         dockerfile: this.path,
         tag: this.name,
+        target: this.target,
         verbose: options.provision_verbose,
         stdout: options.stdout
       };


### PR DESCRIPTION
This adds support for stopping a multi stage docker build at a specific
target.

E.g.:

  image: { dockerfile: 'foo/Dockerfile', target: 'stage-bar' }

Will stop the docker build after the 'stage-bar' stage of a multi-stage
build

