### PR TITLE
Fix problems with new rsync version (3.2.3)

### DIFF
--- a/src/cli/error_handler.js
+++ b/src/cli/error_handler.js
@@ -29,7 +29,8 @@ export function handler(error, options = {}) {
     let isError = error instanceof Error || error instanceof AzkError;
     if (!isError) {
       // no error type
-      log.debug(`[error-handler] expected an error but got: "${error}"`);
+      let error_str = JSON.stringify(error);
+      log.debug(`[error-handler] expected an error but got: ${error_str}`);
       return 1;
     }
 

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -93,7 +93,7 @@ export default class Sync {
         throw { err: message, code: error_code };
       }
 
-      var _version = message.match(/.*version\ (\d+\.\d+\.\d+)/);
+      var _version = message.match(/.*version\ v?(\d+\.\d+\.\d+)/);
       if (!_.isEmpty(_version) && _version.length >= 2) {
         return _version[1];
       } else {


### PR DESCRIPTION
After upgrading `rsync` on my PC to 3.2.3 (Arch Linux), `azk` agent stopped working:
```
$ azk agent -l debug start
…
debug: [error-handler] expected an error but got: "[object Object]"
$ echo $?
1
$ 
```

This PR fixes both the unhelpful error message and the underlying problem (new output format for `rsync --version`).